### PR TITLE
Dockerfile replacement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ Thumbs.db
 ehthumbs.db
 
 # local dev
-Gemfile.lock
+# Gemfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,33 @@
-FROM jekyll/jekyll
+FROM alpine:3.11
 
-COPY --chown=jekyll:jekyll Gemfile .
-COPY --chown=jekyll:jekyll Gemfile.lock .
+# Metadata
+MAINTAINER guillaumefe "guillaume.ferron@gmail.com"
+LABEL version="1.0"
+LABEL description="OpenStopCovid website"
 
-RUN bundle install --quiet --clean
+# Specificy the branch to land
+ARG br="fr"
 
-CMD ["jekyll", "serve"]
+# Update, upgrade, install host packages, clean apk cache
+RUN apk update && apk upgrade
+RUN apk add ruby ruby-bundler ruby-dev
+RUN apk add alpine-sdk zlib-dev ruby-bigdecimal
+RUN rm -rf /var/cache/apk/*
+
+# Update bundler (fix)
+RUN gem install bundler --no-document
+RUN bundle config --global silence_root_warning 1
+
+# Set environment
+RUN mkdir /srv/openstopcovid
+COPY . /srv/openstopcovid
+WORKDIR /srv/openstopcovid
+RUN git stash
+RUN git checkout $br
+
+# Build OpenStopCovid website
+RUN bundle
+
+# Prepare the run for OpenStopCovid website
+EXPOSE 4000
+CMD ["bundle", "exec", "jekyll", "serve", "--host", "0.0.0.0"]

--- a/Dockerfile.permissionsproblem
+++ b/Dockerfile.permissionsproblem
@@ -1,0 +1,8 @@
+FROM jekyll/jekyll AS jekyll
+
+COPY --chown=jekyll:jekyll Gemfile .
+COPY --chown=jekyll:jekyll Gemfile.lock .
+
+RUN bundle install --quiet --clean
+
+CMD ["jekyll", "serve"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source 'https://rubygems.org'
 
-gem "github-pages", group: :jekyll_plugins
-
 # enable tzinfo-data for local build
 # gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
-gem 'jekyll-paginate'
+#
+gem "json"
+gem "webrick"
+gem "jekyll-paginate"
+gem "github-pages", group: :jekyll_plugins


### PR DESCRIPTION
Since I've been unable to make the current dockerfile working.
```
Step 4/5 : RUN bundle install --quiet --clean
 ---> Running in 7fd0d08ded88
[DEPRECATED] The `--clean` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set clean 'true'`, and stop using this flag
Bundler::PermissionError: There was an error while trying to write to
`/usr/gem/cache`. It is likely that you need to grant write permissions for that
path.
An error occurred while installing minitest (5.14.0), and Bundler cannot
continue.
Make sure that `gem install minitest -v '5.14.0' --source
'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  github-pages was resolved to 204, which depends on
    jekyll-mentions was resolved to 1.5.1, which depends on
      html-pipeline was resolved to 2.12.3, which depends on
        activesupport was resolved to 6.0.2.2, which depends on
          minitest
The command '/bin/sh -c bundle install --quiet --clean' returned a non-zero code: 5
```