### PR TITLE
Fix horizontal scroll bar on about page

### DIFF
--- a/_includes/timeline.html
+++ b/_includes/timeline.html
@@ -33,9 +33,9 @@ ul.timeline > li:before {
 
 <!------ Include the above in your HEAD tag ---------->
 
-<div class="container mt-5 mb-5">
+<div class="container-fluid">
 	<div class="row">
-		<div class="col-md-6 offset-md-3">
+		<div class="col-md-12">
 			<ul class="timeline">
 				<li>
 					<a href="#">Création de la communauté (09/03/2020)</a>


### PR DESCRIPTION
It happens between breakpoints, switching to fluid make the timeline to spread across the available space without generating the scroll bar.

Disclaimer: not a Bootstrap expert, there are probably other ways to fix that.
